### PR TITLE
Fixed bug for create cohort issue

### DIFF
--- a/qa-portal-services/cohort-api/src/main/java/com/qa/portal/cohort/services/CohortManagementService.java
+++ b/qa-portal-services/cohort-api/src/main/java/com/qa/portal/cohort/services/CohortManagementService.java
@@ -28,7 +28,7 @@ public class CohortManagementService {
 
     public QaCohortDto createCohort(QaCohortDto cohortDetails) {
         createCohortOperation.createCohort(cohortDetails);
-        keycloakCohortResourceManager.createCohort(cohortDetails.getName());
+        keycloakCohortResourceManager.createCohort(cohortDetails.getName().replace(' ', '_'));
         keycloakUserResourceManager.updateCohortMembers(cohortDetails);
         return cohortDetails;
     }


### PR DESCRIPTION
Edited cohort management service to automatically format cohort name in a way that is consistent with Keycloak documentation so that no error messages display when creating or updating cohorts with spaces in their name